### PR TITLE
change to new name for python module

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@
 Gnu Radio is an open-source development toolkit, capable of simulating real-world radio systems. It is a modular flow-based framework,
 in which you piece together predefined functions and operations to develop your own communication system. 
 
-This code provides an implementation of a receive block for the FlexRadio 6K series. It depends upon the FlexModule module.
+This code provides an implementation of a receive block for the FlexRadio 6K series. It depends upon the flexclient python module, which can be installed with pip.
 
 

--- a/python/FlexSource.py
+++ b/python/FlexSource.py
@@ -22,10 +22,10 @@
 
 import numpy
 from gnuradio import gr
-from FlexModule.SmartLink import SmartLink
-from FlexModule.Radio import Radio
+from flexclient.SmartLink import SmartLink
+from flexclient.Radio import Radio
 from time import sleep
-import FlexModule.DataHandler
+import flexclient.DataHandler
 
 class FlexSource(gr.sync_block):
     """
@@ -45,7 +45,7 @@ class FlexSource(gr.sync_block):
         self.flexRadio = Radio(self.radioInfo, self.smartLink)
 
         if self.flexRadio.serverHandle:
-            receiveThread = FlexModule.DataHandler.ReceiveData(self.flexRadio)
+            receiveThread = flexclient.DataHandler.ReceiveData(self.flexRadio)
             receiveThread.start()
 
             self.flexRadio.UpdateAntList()


### PR DESCRIPTION
The python module was renamed, so use the new name